### PR TITLE
updating kotlin-wrappers, including react-legacy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ fun versionOf(name: String, isWrapper: Boolean = true): String {
 
 dependencies {
     implementation("org.jetbrains.kotlin-wrappers:kotlin-react:${versionOf("react")}")
+    implementation("org.jetbrains.kotlin-wrappers:kotlin-react-legacy:${versionOf("react")}")
     implementation("org.jetbrains.kotlin-wrappers:kotlin-react-dom:${versionOf("react")}")
 
     implementation(npm("react-test-renderer", versionOf("react", isWrapper = false)))

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 version.react=17.0.2
-version.wrappers=pre.281-kotlin-1.6.10
+version.wrappers=pre.293-kotlin-1.6.10

--- a/src/test/kotlin/TestComponent.kt
+++ b/src/test/kotlin/TestComponent.kt
@@ -1,8 +1,9 @@
 package mysticfall.kotlin.react.test
 
 import react.*
-import react.dom.div
-import react.dom.h1
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.h1
+import react.dom.html.ReactHTML.style
 
 external interface TestProps : Props {
     var name: String
@@ -19,8 +20,10 @@ val TestFuncComponent = fc<TestProps> { props ->
         setName("Updated: ${props.name}")
     }
 
-    div(classes = "test-component") {
-        h1(classes = "title") {
+    div {
+        attrs.className = "test-component"
+        h1 {
+            attrs.className = "title"
             +name
         }
     }
@@ -39,8 +42,10 @@ class TestClassComponent(props: TestProps) : RComponent<TestProps, TestState>(pr
     }
 
     override fun RBuilder.render() {
-        div(classes = "test-component") {
-            h1(classes = "title") {
+        div {
+            attrs.className = "test-component"
+            h1 {
+                attrs.className = "title"
                 +state.name
             }
         }

--- a/src/test/kotlin/TestInstanceTest.kt
+++ b/src/test/kotlin/TestInstanceTest.kt
@@ -2,6 +2,11 @@ package mysticfall.kotlin.react.test
 
 import kotlinext.js.jso
 import react.dom.*
+import react.dom.html.ReactHTML.a
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.h1
+import react.dom.html.ReactHTML.h5
+import react.dom.html.ReactHTML.p
 import react.react
 import kotlin.js.json
 import kotlin.test.*
@@ -18,7 +23,8 @@ class TestInstanceTest : ReactTestSupport {
                 div {
                     +"Div 3"
 
-                    div(classes = "selected") {
+                    div {
+                        attrs.className = "selected"
                         +"Div 4"
                     }
                 }
@@ -63,7 +69,8 @@ class TestInstanceTest : ReactTestSupport {
     fun testFindAll() {
         val renderer = render {
             div {
-                div(classes = "selected") {
+                div {
+                    attrs.className = "selected"
                     +"Div 1"
                 }
                 div {
@@ -72,7 +79,8 @@ class TestInstanceTest : ReactTestSupport {
                 div {
                     +"Div 3"
 
-                    div(classes = "selected") {
+                    div {
+                        attrs.className = "selected"
                         +"Div 4"
                     }
                 }
@@ -354,7 +362,8 @@ class TestInstanceTest : ReactTestSupport {
     fun testFindByPropsJson() {
         val renderer = render {
             div {
-                a(classes = "selected") {
+                a {
+                    attrs.className = "selected"
                     attrs.href = "#anchor1"
 
                     +"Link 1"
@@ -364,7 +373,8 @@ class TestInstanceTest : ReactTestSupport {
 
                     +"Link 2"
                 }
-                a(classes = "selected") {
+                a {
+                    attrs.className = "selected"
                     +"Link 3"
                 }
             }
@@ -382,7 +392,8 @@ class TestInstanceTest : ReactTestSupport {
     fun testFindByPropsJsonNoMatch() {
         val renderer = render {
             div {
-                a(classes = "selected") {
+                a {
+                    attrs.className = "selected"
                     +"Link 1"
                 }
             }
@@ -399,10 +410,12 @@ class TestInstanceTest : ReactTestSupport {
     fun testFindByPropsJsonMultipleMatches() {
         val renderer = render {
             div {
-                a(classes = "selected") {
+                a {
+                    attrs.className = "selected"
                     +"Link 1"
                 }
-                a(classes = "selected") {
+                a {
+                    attrs.className = "selected"
                     +"Link 2"
                 }
             }
@@ -463,7 +476,8 @@ class TestInstanceTest : ReactTestSupport {
     fun testFindAllByPropsJsonNoMatch() {
         val renderer = render {
             div {
-                a(classes = "selected") {
+                a {
+                    attrs.className = "selected"
                     attrs.href = "#anchor1"
                 }
             }
@@ -530,7 +544,8 @@ class TestInstanceTest : ReactTestSupport {
     fun testProps() {
         val renderer = render {
             div {
-                h5(classes = "title") {
+                h5 {
+                    attrs.className = "title"
                     +"Heading"
                 }
                 TestFuncComponent {
@@ -555,7 +570,8 @@ class TestInstanceTest : ReactTestSupport {
     fun testParent() {
         val renderer = render {
             div {
-                div(classes = "header") {
+                div {
+                    attrs.className = "header"
                     p {
                         +"Body"
                     }

--- a/src/test/kotlin/TestRendererTest.kt
+++ b/src/test/kotlin/TestRendererTest.kt
@@ -2,7 +2,7 @@ package mysticfall.kotlin.react.test
 
 import org.w3c.dom.Element
 import react.*
-import react.dom.div
+import react.dom.html.ReactHTML.div
 import kotlin.js.json
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -51,15 +51,13 @@ class TestRendererTest : ReactTestSupport {
           |{
           |  "type": "div",
           |  "props": {
-          |     "className": "test-component",
-          |     "style": {}
+          |     "className": "test-component"
           |  },
           |  "children": [
           |     {
           |         "type": "h1",
           |         "props": {
-          |             "className": "title",
-          |             "style": {}
+          |             "className": "title"
           |         },
           |         "children": [
           |             "Updated: Test"
@@ -92,12 +90,12 @@ class TestRendererTest : ReactTestSupport {
     fun testUpdate() = withComponents { type, component ->
         act {
             update(component) {
-                div(classes = "test") {}
+                div { attrs.className = "test"}
             }
         }
 
         val actual = JSON.stringify(component.toJSON())
-        val expected = """{"type":"div","props":{"className":"test","style":{}},"children":null}"""
+        val expected = """{"type":"div","props":{"className":"test"},"children":null}"""
 
         assertEquals(expected, actual, "Unexpected component state after update for $type")
     }
@@ -129,7 +127,8 @@ class TestRendererTest : ReactTestSupport {
                 setName(elem.current?.className ?: "no ref")
             }
 
-            div(classes = "test-component") {
+            div {
+                attrs.className = "test-component"
                 ref = elem
 
                 +name


### PR DESCRIPTION
Updated for compatibility with the latest builds of kotlin-wrappers. I assume the empty style blocks were non-important, but LMK if there's anything else to tweak.

No attempt here to migrate to the new childrenbuilder system.